### PR TITLE
Minor tuning of Mutiny decorators

### DIFF
--- a/frameworks/Java/quarkus/run_quarkus.sh
+++ b/frameworks/Java/quarkus/run_quarkus.sh
@@ -15,6 +15,7 @@ JAVA_OPTIONS="-server \
   -Dvertx.threadChecks=false \
   -Dvertx.disableContextTimings=true \
   -Dhibernate.allow_update_outside_transaction=true \
+  -Dmutiny.disableCallBackDecorators \
   -Djboss.threads.eqe.statistics=false \
   $@"
 


### PR DESCRIPTION

This disables some internal interceptors used to CP - which we don't need.